### PR TITLE
Extract OpenAPI 2 / OpenAPI 3 parsing code

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -9,6 +8,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/kusk/spec"
 )
 
 var (
@@ -24,12 +25,8 @@ var (
 				log.Fatal(errors.New("no openapi or swagger definition provided"))
 			}
 
-			loader := openapi3.Loader{
-				Context: context.Background(),
-			}
-
 			var err error
-			apiSpecContents, err = loader.LoadFromFile(apiSpecPath)
+			apiSpecContents, err = spec.ParseFromFile(apiSpecPath)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/generators/ambassador/ambassador_test.go
+++ b/generators/ambassador/ambassador_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/kusk/spec"
 )
 
 type testCase struct {
@@ -18,7 +20,7 @@ func TestAmbassador(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := require.New(t)
 
-			spec, err := parseSpec([]byte(testCase.spec))
+			spec, err := spec.Parse([]byte(testCase.spec))
 			r.NoError(err, "failed to parse spec")
 
 			mappings, err := GenerateMappings(testCase.options, spec)


### PR DESCRIPTION
This PR extracts the code used to parse both OpenAPI 2 / OpenAPI 3 in both YAML and JSON to be used globally.