### PR TITLE
WIP: Support generation of Ambassador 2.0 AmbassadorMappings

### DIFF
--- a/cmd/ambassador.go
+++ b/cmd/ambassador.go
@@ -24,6 +24,8 @@ var (
 	basePath            string
 	trimPrefix          string
 	rootOnly            bool
+	usePreRelease       bool
+	hostname            string
 )
 
 func generateMappings() {
@@ -34,6 +36,8 @@ func generateMappings() {
 		BasePath:         basePath,
 		TrimPrefix:       trimPrefix,
 		RootOnly:         rootOnly,
+		UsePreRelease:    usePreRelease,
+		Hostname:         hostname,
 	}, apiSpecContents)
 
 	if err != nil {
@@ -78,6 +82,22 @@ func init() {
 		"trim-prefix",
 		"",
 		"",
+		"",
+	)
+
+	ambassadorCmd.Flags().BoolVarP(
+		&usePreRelease,
+		"pre-release",
+		"",
+		false,
+		"--pre-release. Generates pre-release version of mappings",
+	)
+
+	ambassadorCmd.Flags().StringVarP(
+		&hostname,
+		"hostname",
+		"",
+		"*",
 		"",
 	)
 }

--- a/generators/ambassador/options.go
+++ b/generators/ambassador/options.go
@@ -19,4 +19,9 @@ type Options struct {
 	// RootOnly determines whether the mappings will be generated for each route (default)
 	// or for the root prefix only (requires both BasePath and RootOnly options to be set)
 	RootOnly bool
+
+	UsePreRelease bool
+
+	// Ambassador 2.0 supports a hostname field in the AmbassadorMapping resource
+	Hostname string
 }

--- a/generators/ambassador/template.go
+++ b/generators/ambassador/template.go
@@ -1,6 +1,8 @@
 package ambassador
 
 type mappingTemplateData struct {
+	ApiVersion  string
+	Kind        string
 	MappingName string
 
 	AmbassadorNamespace string
@@ -9,20 +11,25 @@ type mappingTemplateData struct {
 	BasePath   string
 	TrimPrefix string
 
-	Method  string
-	Path    string
-	Regex   bool
-	Rewrite bool
+	Hostname string
+	Method   string
+	Path     string
+	Regex    bool
+	Rewrite  bool
 }
 
 var mappingTemplateRaw = `{{range .}}
 ---
-apiVersion: getambassador.io/v2
-kind: Mapping
+apiVersion: {{.ApiVersion}}
+kind: {{.Kind}}
 metadata:
   name: {{.MappingName}}
   namespace: {{.AmbassadorNamespace}}
 spec:
+  {{if .Hostname}}
+  hostname: "{{.Hostname}}"
+  {{end}}
+
   prefix: "{{.BasePath}}{{.Path}}" 
 
   {{if .Regex}}


### PR DESCRIPTION
Implement support for generating Ambassador 2.0 AmbassadorMapping resources

When generating Mappings where root-only is set to false there are some issues I am yet to resolve with reaching the seperate endpoints

resolves #3 

# Testing Instructions
## Spin up new cluster
```
k3d cluster create -p "80:80@loadbalancer" -p "443:443@loadbalancer" --k3s-server-arg '--disable=traefik' --api-port 127.0.0.1:6443 cl2
```

## Install Ambassador
```
kubectl apply -f https://app.getambassador.io/yaml/edge-stack/latest/aes-crds.yaml && \
kubectl wait --for condition=established --timeout=90s crd -lproduct=aes && \
kubectl apply -f https://app.getambassador.io/yaml/edge-stack/latest/aes.yaml && \
kubectl -n ambassador wait --for condition=available --timeout=90s deploy -lproduct=aes
```

## Create AmbassadorListener resources to listen on HTTP and HTTPS
```
kubectl apply -f - <<EOF
---
apiVersion: x.getambassador.io/v3alpha1
kind: AmbassadorListener
metadata:
  name: edge-stack-listener-8080
  namespace: ambassador
spec:
  port: 8080
  protocol: HTTP
  securityModel: XFP
  hostBinding:
    namespace:
      from: ALL
---
apiVersion: x.getambassador.io/v3alpha1
kind: AmbassadorListener
metadata:
  name: edge-stack-listener-8443
  namespace: ambassador
spec:
  port: 8443
  protocol: HTTPS
  securityModel: XFP
  hostBinding:
    namespace:
      from: ALL
EOF
```

## Deploy petstore deployment and service
Grab manifest from up folder

## Generate and apply mappings
```
go run main.go ambassador -i examples/petstore.yaml --pre-release --base-path="/" --service-name "petstore" | kubectl apply -f -

## Resolve service
`curl -Lki http://localhost/`