### PR TITLE
Wizard command fail fast is run without TTY

### DIFF
--- a/cmd/wizard.go
+++ b/cmd/wizard.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"log"
+	"os"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/kusk/spec"
@@ -16,6 +18,10 @@ func init() {
 		Use:   "wizard",
 		Short: "Connects to current Kubernetes cluster and lists available generators",
 		Run: func(cmd *cobra.Command, args []string) {
+			if isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()); !isTTY {
+				log.Fatal("the wizard is only supported in an interactive context i.e. TTY")
+			}
+
 			// parse OpenAPI spec
 			apiSpec, err := spec.ParseFromFile(apiSpecPath)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/knadh/koanf v1.2.0
 	github.com/linkerd/linkerd2 v0.5.1-0.20210701172824-d3cc21da777c
 	github.com/manifoldco/promptui v0.8.0
+	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/spf13/cobra v1.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Resolves #40 

Wizard should only be used in an interactive context, i.e. with a terminal

To prevent the wizard command from hanging when run without TTY, we should fail fast.

### Testing instructions
Vagrant required

Build kusk binary for linux
`export GOOS=linux; go build -o kusk-linux`

Vagrantfile
```
Vagrant.configure("2") do |config|
  config.vm.box = "generic/ubuntu2004"
  config.vm.box_version = "3.1.16"
  config.vm.provision "file", source: "kusk-linux", destination: "kusk-linux"
end
```

Spin up vagrant machine
`vagrant up`

Run wizard command without tty
`vagrant ssh -- -T './kusk-linux wizard -i somefile'`

You can leave `somefile` as is; the command will fail fast before even attempting to read the input file.

Expected ~output
`2021/07/26 13:14:08 the wizard is only supported in an interactive context i.e. TTY`

Cleanup
`vagrant destroy`
`rm Vagrantfile`
`rm kusk-linux`