### PR TITLE
Add support for specifying kusk extension options at the path and http method level.

### DIFF
--- a/examples/petstore/petstore_extension.yaml
+++ b/examples/petstore/petstore_extension.yaml
@@ -37,6 +37,7 @@ tags:
       description: Find out more about our store
       url: http://swagger.io
 x-kusk:
+  disabled: false
   service:
     name: petstore
     port: 80
@@ -45,7 +46,11 @@ x-kusk:
     trim_prefix: /petstore
 paths:
   "/pet":
+    x-kusk:
+      disabled: false
     put:
+      x-kusk:
+        disabled: true
       tags:
         - pet
       summary: Update an existing pet

--- a/options/options.go
+++ b/options/options.go
@@ -5,6 +5,8 @@ import (
 )
 
 type Options struct {
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Namespace for the generated resource. Default value is "default".
 	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 
@@ -22,6 +24,11 @@ type Options struct {
 
 	// NGINXIngress is a set of custom nginx-ingress options.
 	NGINXIngress NGINXIngressOptions `yaml:"nginx_ingress,omitempty" json:"nginx_ingress,omitempty"`
+
+	// TODO(kyle) add rate limiting and retries
+
+	PathOperations       map[string]Options
+	HTTPMethodOperations map[string]Options
 }
 
 func (o *Options) fillDefaults() {
@@ -39,6 +46,14 @@ func (o *Options) fillDefaults() {
 
 	if o.Service.Port == 0 {
 		o.Service.Port = 80
+	}
+
+	if o.PathOperations == nil {
+		o.PathOperations = map[string]Options{}
+	}
+
+	if o.HTTPMethodOperations == nil {
+		o.HTTPMethodOperations = map[string]Options{}
 	}
 }
 

--- a/spec/extension.go
+++ b/spec/extension.go
@@ -10,16 +10,62 @@ import (
 	"github.com/kubeshop/kusk/options"
 )
 
+const kuskExtensionKey = "x-kusk"
+
 // GetOptions would retrieve and parse x-kusk top-level OpenAPI extension
 // that contains Kusk options. If there's no extension found, an empty object will be returned.
 func GetOptions(spec *openapi3.T) (*options.Options, error) {
 	var res options.Options
 
-	if extension, ok := spec.Extensions["x-kusk"]; ok {
+	if extension, ok := spec.Extensions[kuskExtensionKey]; ok {
 		if kuskExtension, ok := extension.(json.RawMessage); ok {
 			err := yaml.Unmarshal(kuskExtension, &res)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse extension: %w", err)
+			}
+		}
+	}
+
+	for pathString, path := range spec.Paths {
+		var pathOpts options.Options
+
+		if extension, ok := path.Extensions[kuskExtensionKey]; ok {
+			if kuskExtension, ok := extension.(json.RawMessage); ok {
+				err := yaml.Unmarshal(kuskExtension, &pathOpts)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse extension: %w", err)
+				}
+
+				if res.PathOperations == nil {
+					res.PathOperations = map[string]options.Options{}
+				}
+
+				res.PathOperations[pathString] = pathOpts
+			}
+		}
+
+		for method, operation := range path.Operations() {
+			if extension, ok := operation.Extensions[kuskExtensionKey]; ok {
+				if kuskExtension, ok := extension.(json.RawMessage); ok {
+					var methodOpts options.Options
+					err := yaml.Unmarshal(kuskExtension, &methodOpts)
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse extension: %w", err)
+					}
+
+					if res.PathOperations == nil {
+						res.PathOperations = map[string]options.Options{}
+					}
+
+					pathOpts = res.PathOperations[pathString]
+
+					if pathOpts.HTTPMethodOperations == nil {
+						pathOpts.HTTPMethodOperations = map[string]options.Options{}
+					}
+
+					pathOpts.HTTPMethodOperations[method] = methodOpts
+					res.PathOperations[pathString] = pathOpts
+				}
 			}
 		}
 	}

--- a/spec/extension_test.go
+++ b/spec/extension_test.go
@@ -1,0 +1,97 @@
+package spec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/kusk/options"
+)
+
+func TestGetOptions(t *testing.T) {
+	var testCases = []struct {
+		name string
+		spec *openapi3.T
+		res  options.Options
+	}{
+		{
+			name: "no extensions",
+			spec: &openapi3.T{},
+			res:  options.Options{},
+		},
+		{
+			name: "global options set",
+			spec: &openapi3.T{
+				ExtensionProps: openapi3.ExtensionProps{
+					Extensions: map[string]interface{}{
+						kuskExtensionKey: json.RawMessage(`{"disabled":true}`),
+					},
+				},
+			},
+			res: options.Options{
+				Disabled: true,
+			},
+		},
+		{
+			name: "path level options set",
+			spec: &openapi3.T{
+				Paths: openapi3.Paths{
+					"/pet": &openapi3.PathItem{
+						ExtensionProps: openapi3.ExtensionProps{
+							Extensions: map[string]interface{}{
+								kuskExtensionKey: json.RawMessage(`{"disabled":true}`),
+							},
+						},
+					},
+				},
+			},
+			res: options.Options{
+				PathOperations: map[string]options.Options{
+					"/pet": {
+						Disabled: true,
+					},
+				},
+			},
+		},
+		{
+			name: "HTTP method level options set",
+			spec: &openapi3.T{
+				Paths: openapi3.Paths{
+					"/pet": &openapi3.PathItem{
+						Put: &openapi3.Operation{
+							ExtensionProps: openapi3.ExtensionProps{
+								Extensions: map[string]interface{}{
+									kuskExtensionKey: json.RawMessage(`{"disabled":true}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			res: options.Options{
+				PathOperations: map[string]options.Options{
+					"/pet": {
+						HTTPMethodOperations: map[string]options.Options{
+							"PUT": {
+								Disabled: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			r := require.New(t)
+
+			actual, err := GetOptions(testCase.spec)
+			r.NoError(err, "failed to get options")
+			r.Equal(testCase.res, *actual)
+		})
+	}
+
+}


### PR DESCRIPTION
resolves #44 

The idea behind this is to create an options chain where the lowest
level options take precedence over the higher level ones. E.g. an option
set at the path level will take precedence over the same option set at
the global level for that path. Likewise for the HTTP method level: If a
setting is present at the HTTP method level it overrides the same
setting set at its path level for that HTTP method.

If a setting isn't provided at the HTTP method or path level, then the
options "chain" should be traversed until an option is found, ideally at
the global level, and if not, then a sensible default value should be
chosen, usually disabling whatever feature the option relates to.