### PR TITLE
Add version cmd

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/kusk/version"
+)
+
+func init() {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints kusk version info",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Version: %s\n", version.Version)
+			fmt.Printf("Git SHA: %s\n", version.Commit)
+			fmt.Printf("Built on: %s\n", version.Date)
+		},
+	}
+
+	rootCmd.AddCommand(versionCmd)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version = "unknown"
+	Commit  = "unknown"
+	Date    = "unknown"
+)


### PR DESCRIPTION
Resolves #75 

Currently it will have to be filled in manually like this:
`go run -ldflags="-X 'github.com/kubeshop/kusk/version.Version=0.0.1' -X 'github.com/kubeshop/kusk/version.Commit=42'" main.go version`
Later on we can fill this within Goreleaser (supports this out of the box).