### PR TITLE
nginx-ingress: warn that path level rate limit is applied separately for each path

### DIFF
--- a/generators/nginx_ingress/nginx_ingress.go
+++ b/generators/nginx_ingress/nginx_ingress.go
@@ -334,7 +334,7 @@ func (g *Generator) shouldSplit(opts *options.Options, spec *openapi3.T) bool {
 
 				if !rateLimitWarned {
 					log.New(os.Stderr, "WARN", log.Lmsgprefix).
-						Printf("Setting a rate limit option on path level would cause a separate rate limit applied for each path")
+						Printf("Setting a rate limit option on the path level would cause a separate rate limit applied for each path")
 
 					rateLimitWarned = true
 				}


### PR DESCRIPTION
This PR adds a warning that setting a custom path-level rate limit option would cause nginx-ingress generator to apply rate limit for each path separately due to mechanics of path splitting.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
